### PR TITLE
Implement PySpark metrics saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The script will preprocess the data, handle class imbalance with SMOTE, train a 
 
 ## Optional: PySpark
 
-For large-scale processing, you can adapt the code to PySpark. A basic structure is provided in `src/pyspark_pipeline.py`.
+For large-scale processing, you can adapt the code to PySpark. A basic structure is provided in `src/pyspark_pipeline.py`. This script now also saves evaluation metrics and plots in the specified results directory.
 =======
 # Credit-Card-Fraud-Detection-Pipeline-Fintech-
 

--- a/src/pyspark_pipeline.py
+++ b/src/pyspark_pipeline.py
@@ -1,11 +1,23 @@
 """PySpark version of the fraud detection pipeline (simplified)."""
 
+import os
+
 import pyspark
 from pyspark.sql import SparkSession
 from pyspark.ml import Pipeline
 from pyspark.ml.feature import VectorAssembler, StandardScaler
 from pyspark.ml.classification import RandomForestClassifier
 from pyspark.ml.evaluation import BinaryClassificationEvaluator
+
+import pandas as pd
+import numpy as np
+from sklearn.metrics import (
+    classification_report,
+    confusion_matrix,
+    roc_auc_score,
+    roc_curve,
+)
+import matplotlib.pyplot as plt
 
 
 def run(csv_path: str, results_dir: str = 'results'):
@@ -23,6 +35,44 @@ def run(csv_path: str, results_dir: str = 'results'):
     evaluator = BinaryClassificationEvaluator(labelCol='Class')
     auc = evaluator.evaluate(predictions)
     print('AUC:', auc)
+
+    os.makedirs(results_dir, exist_ok=True)
+    pdf = predictions.select('Class', 'prediction', 'probability').toPandas()
+    y_true = pdf['Class'].astype(int)
+    y_pred = pdf['prediction'].astype(int)
+    y_prob = pdf['probability'].apply(lambda x: float(x[1]))
+
+    report = classification_report(y_true, y_pred, output_dict=True)
+    cm = confusion_matrix(y_true, y_pred)
+    auc_score = roc_auc_score(y_true, y_prob)
+    fpr, tpr, _ = roc_curve(y_true, y_prob)
+
+    metrics_path = os.path.join(results_dir, 'metrics.txt')
+    with open(metrics_path, 'w') as f:
+        f.write(f"AUC: {auc_score}\n")
+        f.write(pd.DataFrame(report).transpose().to_string())
+        f.write("\nConfusion Matrix:\n")
+        f.write(np.array2string(cm))
+
+    plt.figure()
+    plt.plot(fpr, tpr, label=f'ROC curve (area = {auc_score:0.2f})')
+    plt.plot([0, 1], [0, 1], 'k--')
+    plt.xlabel('False Positive Rate')
+    plt.ylabel('True Positive Rate')
+    plt.title('Receiver Operating Characteristic')
+    plt.legend(loc='lower right')
+    plt.savefig(os.path.join(results_dir, 'roc_curve.png'))
+    plt.close()
+
+    plt.figure()
+    plt.matshow(cm, cmap=plt.cm.Blues)
+    plt.title('Confusion Matrix')
+    plt.colorbar()
+    plt.ylabel('True label')
+    plt.xlabel('Predicted label')
+    plt.savefig(os.path.join(results_dir, 'confusion_matrix.png'))
+    plt.close()
+
     spark.stop()
 
 


### PR DESCRIPTION
## Summary
- compute evaluation metrics in `pyspark_pipeline.py`
- save metrics and plots in the specified directory like the sklearn pipeline
- document PySpark metrics saving in the README

## Testing
- `python -m py_compile src/fraud_detection_pipeline.py src/pyspark_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_68585f2d1a148324be33ba973b762818